### PR TITLE
Interpolate erb on propono configuration yml

### DIFF
--- a/lib/larva/configurator.rb
+++ b/lib/larva/configurator.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module Larva
   class Configurator
 
@@ -37,7 +39,7 @@ module Larva
 
     private
     def parse_config_file(filename)
-      contents = File.read("#{@config_dir}/#{filename}")
+      contents = ERB.new(File.read(File.join(@config_dir, filename))).result
       hash = YAML::load(contents)
       hash.stringify_keys[@env].symbolize_keys
     rescue

--- a/template/config/propono.yml
+++ b/template/config/propono.yml
@@ -1,6 +1,6 @@
 development:
-  access_key: MY-DEV-ACCESS-KEY
-  secret_key: MY-DEV-SECRET-KEY
+  access_key: <%= 'MY-DEV-ACCESS-KEY' %>
+  secret_key: <%= 'MY-DEV-SECRET-KEY' %>
   region: eu-west-1
   application_name: development_larva_spawn
   queue_suffix:


### PR DESCRIPTION
One of the best way to manage secret keys is store them on environment variables, unfortunately I wasn't able to do it in the popono.yml.

Adding a simple erb interpolation fixed that problem. :dancer:

The update on ``template/config/propono.yml`` and the current tests demonstrate that it works well, but I could add more tests if necessary.

Let me know if you have any questions/comments.